### PR TITLE
PluginSetup: Fix flatpak metadata target (#112).

### DIFF
--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -44,7 +44,7 @@ execute_process(
 
 message(STATUS "${CMLOC}OCPN_FLATPAK_CONFIG: ${OCPN_FLATPAK_CONFIG}, UNIX: ${UNIX}")
 if(OCPN_FLATPAK_CONFIG OR OCPN_FLATPAK_BUILD)
-    set(PKG_TARGET "flatpak")
+    set(PKG_TARGET "flatpak-x86_64")
     set(PKG_TARGET_VERSION "18.08") # As of flatpak/*yaml
 elseif(MINGW)
     set(PKG_TARGET "mingw")


### PR DESCRIPTION
Fix flatpak metadata target, flatpak -> flatpak-x86_64, see #112