### PR TITLE
Fix macOS build library paths

### DIFF
--- a/ci/circleci-build-macos-universal.sh
+++ b/ci/circleci-build-macos-universal.sh
@@ -74,8 +74,6 @@ fi
 
 # non-reproducible error on first invocation, seemingly tarball-conf-stamp
 # is not created as required.
-make || make
-make install || make install
 make package || make package
 
 # Create the cached /usr/local archive

--- a/cmake/PluginInstall.cmake
+++ b/cmake/PluginInstall.cmake
@@ -62,31 +62,6 @@ endif (
 
 set(PARENT opencpn)
 
-if (APPLE)
-  install(
-    TARGETS ${PACKAGE_NAME}
-    RUNTIME
-    LIBRARY DESTINATION OpenCPN.app/Contents/PlugIns
-  )
-  if (EXISTS ${PROJECT_SOURCE_DIR}/data)
-    install(
-      DIRECTORY data
-      DESTINATION OpenCPN.app/Contents/SharedSupport/plugins/${PACKAGE_NAME}
-    )
-  endif ()
-
-  if (EXISTS ${PROJECT_SOURCE_DIR}/UserIcons)
-    install(
-      DIRECTORY UserIcons
-      DESTINATION OpenCPN.app/Contents/SharedSupport/plugins/${PACKAGE_NAME}
-    )
-  endif ()
-
-  find_package(ZLIB REQUIRED)
-  target_link_libraries(${PACKAGE_NAME} ${ZLIB_LIBRARIES})
-
-endif (APPLE)
-
 # Based on code from nohal
 if (NOT CMAKE_INSTALL_PREFIX)
   set(CMAKE_INSTALL_PREFIX ${TENTATIVE_PREFIX})
@@ -99,7 +74,6 @@ set(PREFIX_PKGDATA ${PREFIX_DATA}/${PACKAGE_NAME})
 set(PREFIX_LIB lib)
 
 if (WIN32)
-  message(STATUS "${CMLOC}Install Prefix: ${CMAKE_INSTALL_PREFIX}")
   set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/../OpenCPN)
   if (CMAKE_CROSSCOMPILING)
     install(TARGETS ${PACKAGE_NAME} RUNTIME DESTINATION "plugins")
@@ -138,10 +112,7 @@ if (UNIX AND NOT APPLE)
     install(DIRECTORY data
             DESTINATION ${PREFIX_PARENTDATA}/plugins/${PACKAGE_NAME}
     )
-    message(
-      STATUS
-        "${CMLOC}Install data: ${PREFIX_PARENTDATA}/plugins/${PACKAGE_NAME}"
-    )
+    message(STATUS "${CMLOC}Install data: ${PREFIX_PARENTDATA}/plugins/${PACKAGE_NAME}")
   endif ()
   if (EXISTS ${PROJECT_SOURCE_DIR}/UserIcons)
     install(DIRECTORY UserIcons
@@ -153,23 +124,31 @@ if (UNIX AND NOT APPLE)
     set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE
         "${PROJECT_SOURCE_DIR}/script/postinst"
     )
-    message(
-      STATUS
-        "${CMLOC}Install UserIcons: ${PREFIX_PARENTDATA}/plugins/${PACKAGE_NAME}"
-    )
+    message(STATUS "${CMLOC}Install UserIcons: ${PREFIX_PARENTDATA}/plugins/${PACKAGE_NAME}")
   endif ()
 endif (UNIX AND NOT APPLE)
 
 if (APPLE)
-  message(STATUS "${CMLOC}Install Prefix: ${CMAKE_INSTALL_PREFIX}")
+  # On macos, fix paths which points to the build environment, make sure they
+  # refers to runtime locations
+  message(STATUS "${CMLOC}Adjusting library paths")
+  install(CODE "execute_process(
+      COMMAND bash ${PROJECT_SOURCE_DIR}/cmake/fix-macos-libs.sh
+    )"
+  )
+
+  find_package(ZLIB REQUIRED)
+  target_link_libraries(${PACKAGE_NAME} ${ZLIB_LIBRARIES})
 
   # For Apple build, we need to copy the "data" directory contents to the build
   # directory, so that the packager can pick them up.
-  if (NOT EXISTS "${PROJECT_BINARY_DIR}/data/")
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/data/")
-    message("Generating data directory")
+
+  if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/")
+    message(STATUS "${CMLOC}Making directory ${CMAKE_CURRENT_BINARY_DIR}/data/")
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/data/")
   endif ()
 
+  message(STATUS "${CMLOC}Globbing for data files in ${PROJECT_SOURCE_DIR}/data/*")
   file(
     GLOB_RECURSE PACKAGE_DATA_FILES
     LIST_DIRECTORIES true
@@ -177,11 +156,17 @@ if (APPLE)
   )
 
   foreach (_currentDataFile ${PACKAGE_DATA_FILES})
-    message(STATUS "${CMLOC}copying: ${_currentDataFile}")
+    message(STATUS "${CMLOC}Copying ${_currentDataFile} to ${CMAKE_CURRENT_BINARY_DIR}/data")
     file(COPY ${_currentDataFile} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/data)
   endforeach (_currentDataFile)
 
   if (EXISTS ${PROJECT_SOURCE_DIR}/UserIcons)
+    if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/UserIcons/")
+      message(STATUS "${CMLOC}Making directory ${CMAKE_CURRENT_BINARY_DIR}/UserIcons/")
+      file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/UserIcons/")
+    endif ()
+
+    message(STATUS "${CMLOC}Globbing for data icons in ${PROJECT_SOURCE_DIR}/UserIcons/*")
     file(
       GLOB_RECURSE PACKAGE_DATA_FILES
       LIST_DIRECTORIES true
@@ -189,28 +174,34 @@ if (APPLE)
     )
 
     foreach (_currentDataFile ${PACKAGE_DATA_FILES})
-      message(STATUS "${CMLOC}copying: ${_currentDataFile}")
+      message(STATUS "${CMLOC}Copying ${_currentDataFile} to ${CMAKE_CURRENT_BINARY_DIR}/UserIcons")
       file(COPY ${_currentDataFile}
            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/UserIcons
       )
     endforeach (_currentDataFile)
   endif ()
 
-  # On macos, fix paths which points to the build environment, make sure they
-  # refers to runtime locations
-  message(STATUS "${CMLOC}copying: Adjusting MacOS library paths")
-  install(CODE "execute_process(
-      COMMAND bash ${PROJECT_SOURCE_DIR}/cmake/fix-macos-libs.sh
-    )"
-  )
-
+  message(STATUS "${CMLOC}Installing target to OpenCPN.app/Contents/PlugIns")
   install(
     TARGETS ${PACKAGE_NAME}
     RUNTIME
     LIBRARY DESTINATION OpenCPN.app/Contents/PlugIns
   )
-  message(STATUS "${CMLOC}Install Target: OpenCPN.app/Contents/PlugIns")
+  
+  if (EXISTS ${PROJECT_SOURCE_DIR}/data)
+    install(
+      DIRECTORY data
+      DESTINATION OpenCPN.app/Contents/SharedSupport/plugins/${PACKAGE_NAME}
+    )
+  endif ()
 
+  if (EXISTS ${PROJECT_SOURCE_DIR}/UserIcons)
+    install(
+      DIRECTORY UserIcons
+      DESTINATION OpenCPN.app/Contents/SharedSupport/plugins/${PACKAGE_NAME}
+    )
+  endif ()
+  
 endif (APPLE)
 
 set(CMLOC ${SAVE_CMLOC})


### PR DESCRIPTION
This PR fixes the issue I had building testplugin (and my own derived plugin) for macOS due to incorrect library paths in the dynamic library. See https://github.com/jongough/testplugin_pi/issues/437.

I was able to fix this by changing the order of the commands in PluginInstall.cmake, which governs how the files are installed into the package. I now make sure that fix-macos-libs.sh is run on the dynamic library before it is copied into the package structure.

In the process of figuring that out, I did some tidying up in that file, adding more logging and reducing some redundancy. I also removed the redundant calls to make and make install in circeci-build-macos-universal.sh.